### PR TITLE
Add timestamp to Redis about last update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ This project is part of the [Transitdata Pulsar-pipeline](https://github.com/HSL
 This application fetches information about DatedVehicleJourneys from Pubtrans and writes it to Redis.
 The Redis cache is then used to match DatedVehicleJourney Ids to route name, direction and trip start time
 in the following steps of the pipeline.
+
+Application also stores the timestamp of the latest update in ISO-8601 format (f.ex 2018-12-24T07:07:07.007Z) 
+to Redis after each successful update.

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <common.version>0.2.1</common.version>
+        <common.version>0.2.2</common.version>
     </properties>
 
     <repositories>

--- a/src/main/java/fi/hsl/transitdata/pubtransredisconnect/Main.java
+++ b/src/main/java/fi/hsl/transitdata/pubtransredisconnect/Main.java
@@ -185,7 +185,7 @@ public class Main {
             handleJourneyResultSet(resultSet, jedis);
         }
         catch (Exception e) {
-            e.printStackTrace();
+            log.error("Failed to handle result set", e);
         }
         long elapsed = (System.currentTimeMillis() - now) / 1000;
         log.info("Data handled in " + elapsed + " seconds");
@@ -220,6 +220,7 @@ public class Main {
 
         try {
             handleStopResultSet(resultSet, jedis);
+            updateTimestamp(jedis);
         }
         catch (Exception e) {
             log.error("Exception while handling resultset", e);
@@ -234,6 +235,13 @@ public class Main {
             log.error("Exception while closing statement", e);
         }
 
+    }
+
+    void updateTimestamp(Jedis jedis) {
+        OffsetDateTime now = OffsetDateTime.now();
+        String ts = DateTimeFormatter.ISO_INSTANT.format(now);
+        log.info("Updating Redis with latest timestamp: " + ts);
+        jedis.set(TransitdataProperties.KEY_LAST_CACHE_UPDATE_TIMESTAMP, ts);
     }
 
     private void handleJourneyResultSet(ResultSet resultSet, Jedis jedis) throws Exception {


### PR DESCRIPTION
Next steps in the pipeline can then optionally check the last timestamp when cache was updated.