### PR TITLE
Fix: Close ResultSet quickly for JourneyResultSetProcessor

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -6,12 +6,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - name: Set up JDK 24
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '24'
           cache: 'maven'
       - name: Build with Maven
         run: mvn --file pom.xml clean install
@@ -28,7 +28,7 @@ jobs:
     # Run only on develop branch
     if: github.ref == 'refs/heads/develop'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Download .jar file
         uses: actions/download-artifact@v4
         with:
@@ -47,7 +47,7 @@ jobs:
     # Run only for tagged commits
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Download .jar file
         uses: actions/download-artifact@v4
         with:
@@ -66,7 +66,7 @@ jobs:
     # Run only on aks-dev branch
     if: github.ref == 'refs/heads/aks-dev'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Download .jar file
         uses: actions/download-artifact@v4
         with:
@@ -85,7 +85,7 @@ jobs:
     # Run only on run-as-cronjob branch
     if: github.ref == 'refs/heads/run-as-cronjob'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Download .jar file
         uses: actions/download-artifact@v4
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.hsl.transitdata</groupId>
     <artifactId>transitdata-cache-bootstrapper</artifactId>
-    <version>2.0.1</version>
+    <version>3.0.0</version>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <common.version>2.0.3-RC8</common.version>
+        <maven.compiler.source>24</maven.compiler.source>
+        <maven.compiler.target>24</maven.compiler.target>
+        <common.version>2.0.2.0</common.version>
     </properties>
 
     <repositories>
@@ -93,8 +93,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>24</maven.compiler.source>
         <maven.compiler.target>24</maven.compiler.target>
-        <common.version>2.0.2.0</common.version>
+        <common.version>2.0.2.1</common.version>
     </properties>
 
     <repositories>

--- a/src/main/java/fi/hsl/transitdata/pubtransredisconnect/JourneyResultSetProcessor.java
+++ b/src/main/java/fi/hsl/transitdata/pubtransredisconnect/JourneyResultSetProcessor.java
@@ -24,7 +24,11 @@ public class JourneyResultSetProcessor extends AbstractResultSetProcessor {
         int lookupCounter = 0;
         int rowCounter = 0;
 
-        while(resultSet.next()) {
+        while (resultSet.next()) {
+            Map<String, Map<String, String>> records = new HashMap<>();
+            // FIXME: read resultSet into records
+        }
+        for (Map<String, String> record : records) {
             rowCounter++;
             final Map<String, String> values = new HashMap<>();
             values.put(TransitdataProperties.KEY_ROUTE_NAME, resultSet.getString(queryUtils.ROUTE_NAME));

--- a/src/main/java/fi/hsl/transitdata/pubtransredisconnect/JourneyResultSetProcessor.java
+++ b/src/main/java/fi/hsl/transitdata/pubtransredisconnect/JourneyResultSetProcessor.java
@@ -5,15 +5,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class JourneyResultSetProcessor extends AbstractResultSetProcessor {
 
     private static final Logger log = LoggerFactory.getLogger(JourneyResultSetProcessor.class);
-
-    private String from;
-    private String to;
+    
+    private record JourneyResultItem(
+            String dvjId, String routeName, String direction, String operatingDay, String startTime) {};
 
     public JourneyResultSetProcessor(final RedisUtils redisUtils, QueryUtils queryUtils) {
         super(redisUtils, queryUtils);
@@ -23,20 +25,31 @@ public class JourneyResultSetProcessor extends AbstractResultSetProcessor {
         int tripInfoCounter = 0;
         int lookupCounter = 0;
         int rowCounter = 0;
+        
+        List<JourneyResultItem> journeyResultItems = new ArrayList<>();
 
         while (resultSet.next()) {
-            Map<String, Map<String, String>> records = new HashMap<>();
-            // FIXME: read resultSet into records
+            JourneyResultItem journeyResultItem = new JourneyResultItem(
+                    resultSet.getString(queryUtils.DVJ_ID),
+                    resultSet.getString(queryUtils.ROUTE_NAME),
+                    resultSet.getString(queryUtils.DIRECTION),
+                    resultSet.getString(queryUtils.OPERATING_DAY),
+                    resultSet.getString(queryUtils.START_TIME));
+            
+            journeyResultItems.add(journeyResultItem);
         }
-        for (Map<String, String> record : records) {
+        
+        QueryProcessor.closeQuery(resultSet, -1L);
+        
+        for (JourneyResultItem journeyResultItem : journeyResultItems) {
             rowCounter++;
             final Map<String, String> values = new HashMap<>();
-            values.put(TransitdataProperties.KEY_ROUTE_NAME, resultSet.getString(queryUtils.ROUTE_NAME));
-            values.put(TransitdataProperties.KEY_DIRECTION, resultSet.getString(queryUtils.DIRECTION));
-            values.put(TransitdataProperties.KEY_START_TIME, resultSet.getString(queryUtils.START_TIME));
-            values.put(TransitdataProperties.KEY_OPERATING_DAY, resultSet.getString(queryUtils.OPERATING_DAY));
+            values.put(TransitdataProperties.KEY_ROUTE_NAME, journeyResultItem.routeName);
+            values.put(TransitdataProperties.KEY_DIRECTION, journeyResultItem.direction);
+            values.put(TransitdataProperties.KEY_START_TIME, journeyResultItem.startTime);
+            values.put(TransitdataProperties.KEY_OPERATING_DAY, journeyResultItem.operatingDay);
 
-            final String key = TransitdataProperties.REDIS_PREFIX_DVJ + resultSet.getString(queryUtils.DVJ_ID);
+            final String key = TransitdataProperties.REDIS_PREFIX_DVJ + journeyResultItem.dvjId;
             String response = redisUtils.setValues(key, values);
 
             if (redisUtils.checkResponse(response)) {
@@ -45,22 +58,22 @@ public class JourneyResultSetProcessor extends AbstractResultSetProcessor {
 
                 //Insert a composite key that allows reverse lookup of the dvj id
                 //The format is route-direction-date-time
-                final String joreKey = TransitdataProperties.formatJoreId(resultSet.getString(queryUtils.ROUTE_NAME),
-                        resultSet.getString(queryUtils.DIRECTION), resultSet.getString(queryUtils.OPERATING_DAY),
-                        resultSet.getString(queryUtils.START_TIME));
-                response = redisUtils.setValue(joreKey, resultSet.getString(queryUtils.DVJ_ID));
+                final String joreKey = TransitdataProperties.formatJoreId(
+                        journeyResultItem.routeName, journeyResultItem.direction,
+                        journeyResultItem.operatingDay, journeyResultItem.startTime);
+                response = redisUtils.setValue(joreKey, journeyResultItem.dvjId);
                 if (redisUtils.checkResponse(response)) {
                     redisUtils.setExpire(joreKey);
                     lookupCounter++;
                 } else {
-                    log.error("Failed to set reverse-lookup key {}, Redis returned {}", joreKey, response);
+                    log.error("[OPTIMIZED] Failed to set reverse-lookup key {}, Redis returned {}", joreKey, response);
                 }
             } else {
-                log.error("Failed to set Trip details for key {}, Redis returned {}", key, response);
+                log.error("[OPTIMIZED] Failed to set Trip details for key {}, Redis returned {}", key, response);
             }
         }
 
-        log.info("Inserted {} trip info and {} reverse-lookup keys for {} DB rows", tripInfoCounter, lookupCounter, rowCounter);
+        log.info("[OPTIMIZED] Inserted {} trip info and {} reverse-lookup keys for {} DB rows", tripInfoCounter, lookupCounter, rowCounter);
     }
 
     protected String getQuery() {

--- a/src/main/java/fi/hsl/transitdata/pubtransredisconnect/Main.java
+++ b/src/main/java/fi/hsl/transitdata/pubtransredisconnect/Main.java
@@ -49,7 +49,7 @@ public class Main {
             final StopResultSetProcessor stopResultSetProcessor = new StopResultSetProcessor(redisUtils, queryUtils);
             final MetroJourneyResultSetProcessor metroJourneyResultSetProcessor = new MetroJourneyResultSetProcessor(redisUtils, queryUtils);
             
-            queryProcessor.executeAndProcessQuery(journeyResultSetProcessor);
+            queryProcessor.firstExecuteQueryThenReleaseDbResourcesAndThenHandleResults(journeyResultSetProcessor);
             queryProcessor.executeAndProcessQuery(stopResultSetProcessor);
             queryProcessor.executeAndProcessQuery(metroJourneyResultSetProcessor);
             

--- a/src/main/java/fi/hsl/transitdata/pubtransredisconnect/QueryProcessor.java
+++ b/src/main/java/fi/hsl/transitdata/pubtransredisconnect/QueryProcessor.java
@@ -63,6 +63,7 @@ public class QueryProcessor {
             throw e;
         } catch (Exception e) {
             log.error("[OPTIMIZED] Failed to process query", e);
+            closeQuery(resultSet, now);
         }
         
         long elapsed = (System.currentTimeMillis() - now) / 1000;
@@ -71,11 +72,22 @@ public class QueryProcessor {
     
     private ResultSet executeQuery(final String query) throws SQLException {
         Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(query);
-        return resultSet;
+        return statement.executeQuery(query);
     }
 
     public static void closeQuery(final ResultSet resultSet, long now) {
+        if (resultSet == null) {
+            log.warn("ResultSet is null, nothing to close. {}", now);
+            return;
+        }
+        try {
+            if (resultSet.isClosed()) {
+                log.info("ResultSet is already closed, nothing to close. {}", now);
+                return;
+            }
+        } catch (SQLException e) {
+            log.info("Error occured when trying to check if ResultSet is closed. {}", now);
+        }
         Statement statement = null;
         try { statement = resultSet.getStatement(); } catch (Exception e) {
             log.error("Failed to get Statement", e);

--- a/src/main/java/fi/hsl/transitdata/pubtransredisconnect/QueryProcessor.java
+++ b/src/main/java/fi/hsl/transitdata/pubtransredisconnect/QueryProcessor.java
@@ -44,14 +44,38 @@ public class QueryProcessor {
         long elapsed = (System.currentTimeMillis() - now) / 1000;
         log.info("Data handled in " + elapsed + " seconds");
     }
-
+    
+    public void firstExecuteQueryThenReleaseDbResourcesAndThenHandleResults(final AbstractResultSetProcessor processor) {
+        final String processorName = processor.getClass().getName();
+        long now = System.currentTimeMillis();
+        log.info("[OPTIMIZED] Starting query with result set processor {}. {}", processorName, now);
+        
+        ResultSet resultSet = null;
+        try {
+            final String query = processor.getQuery();
+            log.info("[OPTIMIZED] Executing query... {}", now);
+            resultSet = executeQuery(query);
+            log.info("[OPTIMIZED] Processing result set... {}", now);
+            processor.processResultSet(resultSet);
+            log.info("[OPTIMIZED] Query processed. {}", now);
+        } catch (JedisConnectionException e) {
+            log.error(String.format("[OPTIMIZED] Failed to connect to Redis while running processor %s.", processorName), e);
+            throw e;
+        } catch (Exception e) {
+            log.error("[OPTIMIZED] Failed to process query", e);
+        }
+        
+        long elapsed = (System.currentTimeMillis() - now) / 1000;
+        log.info("[OPTIMIZED] Data handled in " + elapsed + " seconds");
+    }
+    
     private ResultSet executeQuery(final String query) throws SQLException {
         Statement statement = connection.createStatement();
         ResultSet resultSet = statement.executeQuery(query);
         return resultSet;
     }
 
-    private static void closeQuery(final ResultSet resultSet, long now) {
+    public static void closeQuery(final ResultSet resultSet, long now) {
         Statement statement = null;
         try { statement = resultSet.getStatement(); } catch (Exception e) {
             log.error("Failed to get Statement", e);


### PR DESCRIPTION
Fixes [AB#60444](https://dev.azure.com/hslfi/24efe23f-34ba-4a39-aaad-679208cae463/_workitems/edit/60444).

To enable using managed Redis, we need to release the transaction sooner to mitigate the effects of the increased latency.

This branch is a quickfix to do just that before a larger refactoring.
